### PR TITLE
fixed mvn package -Werror

### DIFF
--- a/src/test/java/uk/co/threefi/connect/http/sink/HttpApiWriterTest.java
+++ b/src/test/java/uk/co/threefi/connect/http/sink/HttpApiWriterTest.java
@@ -16,6 +16,7 @@
 package uk.co.threefi.connect.http.sink;
 
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -69,7 +70,7 @@ public class HttpApiWriterTest {
       Assert.assertEquals(HttpSinkConfig.RequestMethod.PUT.toString(),requestInfo.getMethod());
       Assert.assertEquals(endPoint,requestInfo.getUrl());
       Assert.assertEquals(payload,requestInfo.getBody());
-      Assert.assertThat(requestInfo.getHeaders(),hasItems("Content-Type:application/json"));
+      MatcherAssert.assertThat(requestInfo.getHeaders(),hasItems("Content-Type:application/json"));
     }
   }
 
@@ -95,7 +96,7 @@ public class HttpApiWriterTest {
       Assert.assertEquals(HttpSinkConfig.RequestMethod.POST.toString(),requestInfo.getMethod());
       Assert.assertEquals(endPoint,requestInfo.getUrl());
       Assert.assertEquals(payload,requestInfo.getBody());
-      Assert.assertThat(requestInfo.getHeaders(),hasItems("Content-Type:application/json"));
+      MatcherAssert.assertThat(requestInfo.getHeaders(),hasItems("Content-Type:application/json"));
     }
   }
 
@@ -121,7 +122,7 @@ public class HttpApiWriterTest {
       Assert.assertEquals(HttpSinkConfig.RequestMethod.DELETE.toString(),requestInfo.getMethod());
       Assert.assertEquals(endPoint,requestInfo.getUrl());
       Assert.assertEquals(payload,requestInfo.getBody());
-      Assert.assertThat(requestInfo.getHeaders(),hasItems("Content-Type:application/json"));
+      MatcherAssert.assertThat(requestInfo.getHeaders(),hasItems("Content-Type:application/json"));
     }
   }
 
@@ -144,8 +145,8 @@ public class HttpApiWriterTest {
     Assert.assertEquals(1,restHelper.getCapturedRequests().size());
     for( RequestInfo requestInfo : restHelper.getCapturedRequests())
     {
-      Assert.assertThat(requestInfo.getHeaders(),hasItems("Content-Type:application/json"));
-      Assert.assertThat(requestInfo.getHeaders(),hasItems("Cache-Control:no-cache"));
+      MatcherAssert.assertThat(requestInfo.getHeaders(),hasItems("Content-Type:application/json"));
+      MatcherAssert.assertThat(requestInfo.getHeaders(),hasItems("Cache-Control:no-cache"));
     }
   }
 
@@ -169,8 +170,8 @@ public class HttpApiWriterTest {
     Assert.assertEquals(1,restHelper.getCapturedRequests().size());
     for( RequestInfo requestInfo : restHelper.getCapturedRequests())
     {
-      Assert.assertThat(requestInfo.getHeaders(),hasItems("Content-Type:application/json"));
-      Assert.assertThat(requestInfo.getHeaders(),hasItems("Cache-Control:no-cache"));
+      MatcherAssert.assertThat(requestInfo.getHeaders(),hasItems("Content-Type:application/json"));
+      MatcherAssert.assertThat(requestInfo.getHeaders(),hasItems("Cache-Control:no-cache"));
     }
   }
 


### PR DESCRIPTION
@thomaskwscott mvn package was failing because there were warnings while running test. The Assert.assertThat was deprecated and was throwing the warnings. Fixed them.